### PR TITLE
Track worktrees and branches for cleanup

### DIFF
--- a/src/commands/create.rs
+++ b/src/commands/create.rs
@@ -134,6 +134,13 @@ fn create_worktree_internal(
     // Store origin information for back navigation
     store_origin_info(&storage, &repo_name, branch, &repo_path)?;
 
+    // Mark branch as managed only if we created it in this operation
+    if create_branch {
+        if let Err(e) = storage.mark_branch_managed(&repo_name, branch) {
+            eprintln!("Warning: Failed to mark branch as managed: {}", e);
+        }
+    }
+
     println!("✓ Worktree created successfully!");
     println!("  Branch: {}", branch);
     println!("  Path: {}", worktree_path.display());

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -101,7 +101,14 @@ pub fn remove_worktree_with_provider(
     if delete_branch {
         println!("Deleting branch: {}", branch_name);
         match git_repo.delete_branch(&branch_name) {
-            Ok(_) => println!("✓ Branch deleted successfully"),
+            Ok(_) => {
+                println!("✓ Branch deleted successfully");
+                // Unmark managed status
+                if let Err(e) = storage.unmark_branch_managed(&repo_name, &branch_name) {
+                    println!("⚠ Warning: Failed to unmark managed branch: {}", e);
+                }
+                // Optionally remove mapping for this branch if desired; keep for cleanup symmetry
+            }
             Err(e) => println!("⚠ Warning: Failed to delete branch: {}", e),
         }
     }

--- a/tests/cleanup_tests.rs
+++ b/tests/cleanup_tests.rs
@@ -1,0 +1,88 @@
+#![allow(clippy::unwrap_used)] // Tests use unwrap for simplicity
+
+use anyhow::Result;
+use assert_fs::prelude::*;
+use predicates::prelude::*;
+
+use test_support::CliTestEnvironment;
+
+/// When a managed branch's worktree dir is removed manually, cleanup deletes only that managed branch
+#[test]
+fn test_cleanup_deletes_only_managed_orphan_branches() -> Result<()> {
+    let env = CliTestEnvironment::new()?;
+
+    // Create a managed branch via CLI
+    env.run_command(&["create", "feature/managed-a"])?.assert().success();
+
+    // Create an independent branch NOT via CLI (unmanaged)
+    // Create branch and do not create a worktree
+    {
+        let output = std::process::Command::new("git")
+            .args(["checkout", "-b", "feature/unmanaged-b"]) // create branch
+            .current_dir(env.repo_dir.path())
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        // switch back to default branch to avoid detachment
+        let _ = std::process::Command::new("git")
+            .args(["checkout", "master"]) // repo init likely creates master
+            .current_dir(env.repo_dir.path())
+            .output()
+            .unwrap();
+    }
+
+    // Simulate orphaning: remove the managed worktree directory
+    let managed_path = env.worktree_path("feature/managed-a");
+    managed_path.assert(predicate::path::is_dir());
+    managed_path.remove_dir_all()?;
+
+    // Run cleanup
+    env.run_command(&["cleanup"])?.assert().success();
+
+    // Managed branch should be deleted
+    // Verify by trying to checkout it fails
+    let checkout = std::process::Command::new("git")
+        .args(["checkout", "feature/managed-a"]) 
+        .current_dir(env.repo_dir.path())
+        .output()
+        .unwrap();
+    assert!(!checkout.status.success());
+
+    // Unmanaged branch should still exist
+    let checkout_unmanaged = std::process::Command::new("git")
+        .args(["checkout", "feature/unmanaged-b"]) 
+        .current_dir(env.repo_dir.path())
+        .output()
+        .unwrap();
+    assert!(checkout_unmanaged.status.success());
+
+    Ok(())
+}
+
+/// When a branch is deleted outside the CLI, cleanup prunes the orphaned worktree directory and metadata
+#[test]
+fn test_cleanup_prunes_orphaned_directories_for_deleted_branches() -> Result<()> {
+    let env = CliTestEnvironment::new()?;
+
+    // Create a managed branch via CLI
+    env.run_command(&["create", "feature/to-be-deleted"])?.assert().success();
+    let wt_path = env.worktree_path("feature/to-be-deleted");
+    wt_path.assert(predicate::path::is_dir());
+
+    // Delete the branch outside the CLI
+    let output = std::process::Command::new("git")
+        .args(["branch", "-D", "feature/to-be-deleted"]) 
+        .current_dir(env.repo_dir.path())
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    // Run cleanup
+    env.run_command(&["cleanup"])?.assert().success();
+
+    // Worktree directory should be pruned
+    wt_path.assert(predicate::path::missing());
+
+    Ok(())
+}
+


### PR DESCRIPTION
Add managed branch tracking to make `cleanup` safe and prune orphaned worktree directories.

---
<a href="https://cursor.com/background-agent?bcId=bc-19409319-8bd6-48f9-b89b-13fbdb09f229">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-19409319-8bd6-48f9-b89b-13fbdb09f229">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

