### PR TITLE
Add interactive picker for `--from` flag in worktree create

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -16,7 +16,8 @@
       "WebSearch",
       "Bash(rustc --version)",
       "Bash(cargo --version)",
-      "mcp__codanna__get_index_info"
+      "mcp__codanna__get_index_info",
+      "Read(//tmp/**)"
     ],
     "deny": [],
     "ask": []

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  release-checks:
+    name: Release Checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Set up cargo cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          prefix-key: "v0-rust"
+
+      - name: Check formatting
+        run: cargo fmt --check
+
+      - name: Run Clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Run tests
+        run: cargo test
+
+      - name: Build release
+        run: cargo build --release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Enhanced
+
+- **Interactive Git Reference Selection:**
+  - Improved `worktree create` interactive workflow with hierarchical git reference selection
+  - Two-step selection process: first choose category (Local Branches, Remote Branches, Tags), then select specific reference
+  - Eliminates confusion from trying to select non-selectable separator items
+  - Enhanced user experience with clear categorization and item counts for each group
+  - Maintains all existing functionality while providing cleaner navigation for complex repositories
+
 ## [0.3.2] - 2025-09-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,12 +128,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "cc"
 version = "1.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,6 +206,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
 
 [[package]]
+name = "convert_case"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,15 +241,17 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
-version = "0.25.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.9.3",
  "crossterm_winapi",
- "libc",
+ "derive_more",
+ "document-features",
  "mio",
  "parking_lot",
+ "rustix",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -259,6 +264,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -304,6 +330,15 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "document-features"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
+dependencies = [
+ "litrs",
+]
 
 [[package]]
 name = "dyn-clone"
@@ -358,15 +393,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
 dependencies = [
  "thread_local",
-]
-
-[[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
 ]
 
 [[package]]
@@ -584,17 +610,14 @@ dependencies = [
 
 [[package]]
 name = "inquire"
-version = "0.7.5"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fddf93031af70e75410a2511ec04d49e758ed2f26dad3404a934e0fb45cc12a"
+checksum = "2628910d0114e9139056161d8644a2026be7b117f8498943f9437748b04c9e0a"
 dependencies = [
  "bitflags 2.9.3",
  "crossterm",
  "dyn-clone",
  "fuzzy-matcher",
- "fxhash",
- "newline-converter",
- "once_cell",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -684,6 +707,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
+name = "litrs"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
+
+[[package]]
 name = "lock_api"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -716,23 +745,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.11"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "newline-converter"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b6b097ecb1cbfed438542d16e84fd7ad9b0c76c8a65b7f9039212a3d14dc7f"
-dependencies = [
- "unicode-segmentation",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1249,9 +1269,9 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.14"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "url"
@@ -1356,11 +1376,11 @@ checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1370,21 +1390,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.3",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -1422,12 +1427,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -1440,12 +1439,6 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -1455,12 +1448,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1488,12 +1475,6 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -1503,12 +1484,6 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1524,12 +1499,6 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -1539,12 +1508,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ toml = "0.9"
 dirs = "6.0"
 anyhow = "1.0"
 glob = "0.3"
-inquire = "0.7"
+inquire = "0.9"
 
 [dev-dependencies]
 tempfile = "3.8"

--- a/WARP.md
+++ b/WARP.md
@@ -1,0 +1,101 @@
+# WARP.md
+
+This file provides guidance to WARP (warp.dev) when working with code in this repository.
+
+## Quick Commands
+
+### Build
+- `cargo build` - Standard debug build
+- `cargo build --release` - Optimized release build
+
+### Test  
+- `cargo test` - Run all tests
+- `cargo test --test create_tests` - Run specific integration test file
+- `cargo test commands::create` - Run specific module tests
+- `cargo test -- --ignored` - Run ignored tests
+
+### Code Quality
+- `cargo fmt --all` - Format code
+- `cargo fmt --all --check` - Check formatting
+- `cargo clippy --all-targets --all-features -- -D warnings` - Run linter
+- `cargo check --all-targets --all-features` - Quick syntax check
+
+### Run Binary
+- `cargo run -- list` - Run via cargo (note the `--`)
+- `cargo run -- create feature/my-branch` - Create worktree example
+- `./target/release/worktree-bin list` - Run release binary directly
+
+## Architecture
+
+### Module Structure
+- `src/main.rs` - CLI entry point using clap, dispatches to command modules
+- `src/lib.rs` - Library crate root, exposes modules and `Result` type
+- `src/traits.rs` - `GitOperations` trait for testability and abstraction
+- `src/commands/` - Individual command implementations (create, list, remove, etc.)
+- `src/storage/` - Manages `~/.worktrees/` directory with branch name sanitization
+- `src/config/` - `WorktreeConfig` for `.worktree-config.toml` file copy patterns  
+- `src/git/` - `GitRepo` wrapper around git2 crate, implements `GitOperations`
+- `src/selection.rs` - Interactive selection prompts abstracted for testing
+
+### Key Design Patterns
+- **Trait-based git operations**: `GitOperations` trait enables mocking for tests
+- **Centralized storage**: All worktrees stored under `~/.worktrees/<repo>/<branch>/`
+- **Branch name sanitization**: Converts `feature/auth` to `feature-auth` for filesystem safety
+- **Configuration-driven file copying**: Uses glob patterns from `.worktree-config.toml`
+- **Origin tracking**: Stores origin repository paths for back navigation
+
+### Data Flow
+CLI parsing → command dispatch → commands orchestrate `GitRepo` and `WorktreeStorage` using `WorktreeConfig` → shell integration outputs navigation commands.
+
+### Testing Approach
+- Integration tests in `tests/` using `tempfile` and `temp-env` for isolation
+- Test helpers in `tests/helpers/` for common setup patterns
+- All git operations use temporary repositories, never user's real repos
+
+## Configuration
+
+### Clippy Lints
+- `unwrap_used = "deny"` and `panic = "deny"` enforced in `Cargo.toml`
+- All errors must be handled gracefully with `anyhow::Result`
+
+### MSRV
+- Minimum Supported Rust Version: 1.70.0 (configured in `clippy.toml`)
+
+### Binary Names
+- Binary name: `worktree-bin` (shell wrapper exists for directory navigation)
+- Shell integration generates wrapper functions for bash/zsh/fish
+
+## Release Management
+
+### Tooling
+- Uses `cargo-release` with configuration in `release.toml`
+- Publishing is manual only - never auto-publishes
+
+### Workflow
+1. **Pre-release checks**: 
+   - `cargo fmt --all --check`
+   - `cargo clippy --all-targets --all-features -- -D warnings` 
+   - `cargo test --all-features`
+   - `cargo build --release`
+2. **Version and tag**: `cargo release patch|minor|major`
+3. **Manual publish**: `cargo publish` (after version bump completes)
+
+## Safety and Development Practices
+
+### Error Handling
+- No `unwrap()` or `panic!()` in production code paths (enforced by Clippy)
+- All errors surfaced with actionable messages via `anyhow`
+
+### Path Safety
+- Branch name sanitization for filesystem compatibility
+- All worktree operations scoped to `~/.worktrees/` directory
+- Origin tracking prevents orphaned worktree references
+
+### Shell Integration  
+- Binary outputs shell commands for evaluation, never mutates shell environment directly
+- Directory navigation requires shell wrapper for `jump`/`back` commands
+
+### Testing Isolation
+- Tests use isolated temporary directories and git repositories
+- Never operate against user's actual repositories during testing
+- Comprehensive coverage using `tempfile` and `temp-env` crates

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -1,6 +1,37 @@
 use anyhow::Result;
-use inquire::Select;
+use inquire::{Select, Text, validator::Validation};
+use std::error::Error;
+use std::fmt;
 use std::path::PathBuf;
+
+use crate::git::GitRepo;
+
+/// Type alias for validation functions
+pub type ValidatorFn = fn(&str) -> Result<Validation, Box<dyn Error + Send + Sync>>;
+
+/// Represents a git reference option with visual grouping
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum GitRefOption {
+    /// A selectable git reference
+    Reference { name: String, display: String },
+    /// A visual separator/header (non-selectable)
+    Separator(String),
+}
+
+impl fmt::Display for GitRefOption {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            GitRefOption::Reference { display, .. } => write!(f, "{}", display),
+            GitRefOption::Separator(label) => {
+                if label.is_empty() {
+                    write!(f, "") // Empty separator for spacing
+                } else {
+                    write!(f, "─── {} ───", label)
+                }
+            }
+        }
+    }
+}
 
 /// Trait for providing interactive selection functionality
 /// This allows us to abstract away the interactive prompts for testing
@@ -10,6 +41,18 @@ pub trait SelectionProvider {
     /// # Errors
     /// Returns an error if the selection process fails or user cancels
     fn select(&self, prompt: &str, options: Vec<String>) -> Result<String>;
+
+    /// Present a grouped selection menu with visual separators
+    ///
+    /// # Errors
+    /// Returns an error if the selection process fails or user cancels
+    fn select_grouped(&self, prompt: &str, options: Vec<GitRefOption>) -> Result<String>;
+
+    /// Get text input from the user with validation
+    ///
+    /// # Errors
+    /// Returns an error if the input process fails or user cancels
+    fn get_text_input(&self, prompt: &str, validator: Option<ValidatorFn>) -> Result<String>;
 }
 
 /// Real implementation using inquire::Select for production use
@@ -22,6 +65,72 @@ impl SelectionProvider for RealSelectionProvider {
             .with_vim_mode(true)
             .prompt()?;
         Ok(selection)
+    }
+
+    fn select_grouped(&self, prompt: &str, options: Vec<GitRefOption>) -> Result<String> {
+        // Parse options into groups
+        let mut groups: Vec<(String, Vec<String>)> = Vec::new();
+        let mut current_group_name = String::new();
+        let mut current_group_refs = Vec::new();
+
+        for option in options {
+            match option {
+                GitRefOption::Separator(label) => {
+                    // Save previous group if it exists
+                    if !current_group_refs.is_empty() {
+                        groups.push((current_group_name.clone(), current_group_refs.clone()));
+                        current_group_refs.clear();
+                    }
+                    // Start new group (skip empty separators)
+                    if !label.is_empty() {
+                        current_group_name = label;
+                    }
+                }
+                GitRefOption::Reference { name, .. } => {
+                    current_group_refs.push(name);
+                }
+            }
+        }
+
+        // Add the last group
+        if !current_group_refs.is_empty() {
+            groups.push((current_group_name, current_group_refs));
+        }
+
+        // If we only have one group, select directly from it
+        if groups.len() == 1 {
+            let (_, refs) = &groups[0];
+            return self.select(prompt, refs.clone());
+        }
+
+        // Multiple groups: let user choose group first, then reference
+        let group_names: Vec<String> = groups
+            .iter()
+            .map(|(name, refs)| format!("{} ({} items)", name, refs.len()))
+            .collect();
+
+        let selected_group = self.select("Choose a category:", group_names)?;
+
+        // Find the selected group and its references
+        for (group_name, refs) in groups.iter() {
+            let group_display = format!("{} ({} items)", group_name, refs.len());
+            if group_display == selected_group {
+                return self.select(&format!("Choose from {}:", group_name), refs.clone());
+            }
+        }
+
+        anyhow::bail!("Selected group not found")
+    }
+
+    fn get_text_input(&self, prompt: &str, validator: Option<ValidatorFn>) -> Result<String> {
+        let mut text_prompt = Text::new(prompt);
+
+        if let Some(validation_fn) = validator {
+            text_prompt = text_prompt.with_validator(validation_fn);
+        }
+
+        let result = text_prompt.prompt()?;
+        Ok(result)
     }
 }
 
@@ -46,6 +155,32 @@ impl SelectionProvider for MockSelectionProvider {
         } else {
             anyhow::bail!("Mock response '{}' not found in options", self.response)
         }
+    }
+
+    fn select_grouped(&self, _prompt: &str, options: Vec<GitRefOption>) -> Result<String> {
+        // Extract only the selectable reference names from the grouped options
+        let selectable_values: Vec<String> = options
+            .into_iter()
+            .filter_map(|opt| match opt {
+                GitRefOption::Reference { name, .. } => Some(name),
+                GitRefOption::Separator(_) => None,
+            })
+            .collect();
+
+        // Validate that the response is actually in the selectable options
+        if selectable_values.contains(&self.response) {
+            Ok(self.response.clone())
+        } else {
+            anyhow::bail!(
+                "Mock response '{}' not found in grouped options",
+                self.response
+            )
+        }
+    }
+
+    fn get_text_input(&self, _prompt: &str, _validator: Option<ValidatorFn>) -> Result<String> {
+        // For testing, return a predetermined response
+        Ok(self.response.clone())
     }
 }
 
@@ -76,6 +211,89 @@ pub fn extract_branch_from_selection(selection: &str) -> Result<String> {
         }
     } else {
         anyhow::bail!("Invalid selection format: {}", selection)
+    }
+}
+
+/// Select a git reference interactively using visual separators
+///
+/// # Errors
+/// Returns an error if:
+/// - Git operations fail
+/// - Interactive selection fails or is cancelled
+/// - No git references available
+pub fn select_git_reference_interactive(
+    git_repo: &GitRepo,
+    provider: &dyn SelectionProvider,
+) -> Result<String> {
+    // Get all references
+    let local_branches = git_repo.list_local_branches()?;
+    let remote_branches = git_repo.list_remote_branches()?;
+    let tags = git_repo.list_tags()?;
+
+    if local_branches.is_empty() && remote_branches.is_empty() && tags.is_empty() {
+        anyhow::bail!("No git references found");
+    }
+
+    // Create grouped options with visual separators
+    let mut options = Vec::new();
+
+    // Local branches first (most commonly used)
+    if !local_branches.is_empty() {
+        options.push(GitRefOption::Separator("Local Branches".to_string()));
+        for branch in &local_branches {
+            options.push(GitRefOption::Reference {
+                name: branch.clone(),
+                display: format!("  {}", branch), // Indent for visual grouping
+            });
+        }
+    }
+
+    // Remote branches second
+    if !remote_branches.is_empty() {
+        if !options.is_empty() {
+            // Add spacing if there are previous sections
+            options.push(GitRefOption::Separator(String::new())); // Empty separator for spacing
+        }
+        options.push(GitRefOption::Separator("Remote Branches".to_string()));
+        for branch in &remote_branches {
+            options.push(GitRefOption::Reference {
+                name: branch.clone(),
+                display: format!("  {}", branch), // Indent for visual grouping
+            });
+        }
+    }
+
+    // Tags last
+    if !tags.is_empty() {
+        if !options.is_empty() {
+            // Add spacing if there are previous sections
+            options.push(GitRefOption::Separator(String::new())); // Empty separator for spacing
+        }
+        options.push(GitRefOption::Separator("Tags".to_string()));
+        for tag in &tags {
+            options.push(GitRefOption::Reference {
+                name: tag.clone(),
+                display: format!("  {}", tag), // Indent for visual grouping
+            });
+        }
+    }
+
+    if options.is_empty() {
+        anyhow::bail!("No git references found");
+    }
+
+    provider.select_grouped("Select git reference to create worktree from:", options)
+}
+
+/// Helper function to extract reference name from formatted selection
+///
+/// # Errors
+/// Returns an error if the selection string is not in expected format
+pub fn extract_reference_from_selection(selection: &str) -> Result<String> {
+    if let Some(space_pos) = selection.find(" (") {
+        Ok(selection[..space_pos].to_string())
+    } else {
+        anyhow::bail!("Invalid reference selection format: {}", selection)
     }
 }
 
@@ -120,5 +338,110 @@ mod tests {
         let invalid_selection = "invalid format";
         assert!(extract_path_from_selection(invalid_selection).is_err());
         assert!(extract_branch_from_selection(invalid_selection).is_err());
+    }
+
+    #[test]
+    fn test_extract_reference_from_selection() {
+        let selection = "main (local branch)";
+        let result = extract_reference_from_selection(selection);
+        assert!(matches!(result, Ok(ref s) if s == "main"));
+
+        let selection = "origin/feature (remote branch)";
+        let result = extract_reference_from_selection(selection);
+        assert!(matches!(result, Ok(ref s) if s == "origin/feature"));
+
+        let selection = "v1.0.0 (tag)";
+        let result = extract_reference_from_selection(selection);
+        assert!(matches!(result, Ok(ref s) if s == "v1.0.0"));
+    }
+
+    #[test]
+    fn test_extract_reference_from_invalid_selection() {
+        let invalid_selection = "invalid format";
+        assert!(extract_reference_from_selection(invalid_selection).is_err());
+    }
+
+    #[test]
+    fn test_git_ref_option_formatting() {
+        // Test GitRefOption display formatting
+        let local_ref = GitRefOption::Reference {
+            name: "main".to_string(),
+            display: "  main".to_string(),
+        };
+        let separator = GitRefOption::Separator("Local Branches".to_string());
+        let empty_separator = GitRefOption::Separator(String::new());
+
+        // Test display formatting
+        assert_eq!(format!("{}", local_ref), "  main");
+        assert_eq!(format!("{}", separator), "─── Local Branches ───");
+        assert_eq!(format!("{}", empty_separator), "");
+
+        // Test that reference names are preserved correctly
+        if let GitRefOption::Reference { name, .. } = local_ref {
+            assert_eq!(name, "main");
+        } else {
+            unreachable!("Expected Reference variant");
+        }
+    }
+
+    #[test]
+    fn test_select_grouped_functionality() {
+        // Create mock provider that will return "main" for any selection
+        let provider = MockSelectionProvider::new("main");
+
+        // Create a grouped list with separators
+        let options = vec![
+            GitRefOption::Separator("Local Branches".to_string()),
+            GitRefOption::Reference {
+                name: "main".to_string(),
+                display: "  main".to_string(),
+            },
+            GitRefOption::Reference {
+                name: "feature".to_string(),
+                display: "  feature".to_string(),
+            },
+            GitRefOption::Separator(String::new()), // Empty separator for spacing
+            GitRefOption::Separator("Remote Branches".to_string()),
+            GitRefOption::Reference {
+                name: "origin/develop".to_string(),
+                display: "  origin/develop".to_string(),
+            },
+        ];
+
+        let result = provider.select_grouped("Choose base for new branch:", options);
+
+        if let Ok(selected) = result {
+            assert_eq!(selected, "main");
+        } else {
+            unreachable!("Selection should succeed in test: {:?}", result);
+        }
+    }
+
+    #[test]
+    fn test_git_ref_option_extraction() {
+        // Test that we can correctly extract names from GitRefOption variants
+        let ref_option = GitRefOption::Reference {
+            name: "origin/feature".to_string(),
+            display: "  origin/feature".to_string(),
+        };
+
+        match ref_option {
+            GitRefOption::Reference { name, .. } => {
+                assert_eq!(name, "origin/feature");
+            }
+            GitRefOption::Separator(_) => {
+                unreachable!("Expected Reference, got Separator");
+            }
+        }
+
+        let separator = GitRefOption::Separator("Remote Branches".to_string());
+        match separator {
+            GitRefOption::Separator(label) => {
+                assert_eq!(label, "Remote Branches");
+            }
+            GitRefOption::Reference { .. } => {
+                unreachable!("Expected Separator, got Reference");
+            }
+        }
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -29,6 +29,21 @@ pub trait GitOperations {
         worktree_path: &Path,
         create_branch: bool,
     ) -> Result<()>;
+    /// Creates a new worktree for the specified branch from a specific starting point
+    ///
+    /// # Errors
+    /// Returns an error if:
+    /// - Failed to create the worktree
+    /// - Branch doesn't exist and create_branch is false
+    /// - Failed to resolve the starting reference
+    /// - Git operations fail
+    fn create_worktree_from(
+        &self,
+        branch_name: &str,
+        worktree_path: &Path,
+        create_branch: bool,
+        from_ref: Option<&str>,
+    ) -> Result<()>;
     /// Removes a worktree from the repository
     ///
     /// # Errors
@@ -55,4 +70,20 @@ pub trait GitOperations {
     /// - Failed to read parent repository configuration
     /// - Failed to set worktree-specific configuration
     fn inherit_config(&self, worktree_path: &Path) -> Result<()>;
+
+    /// Lists all local branches in the repository
+    ///
+    /// # Errors
+    /// Returns an error if git operations fail
+    fn list_local_branches(&self) -> Result<Vec<String>>;
+    /// Lists all remote branches in the repository
+    ///
+    /// # Errors
+    /// Returns an error if git operations fail
+    fn list_remote_branches(&self) -> Result<Vec<String>>;
+    /// Lists all tags in the repository
+    ///
+    /// # Errors
+    /// Returns an error if git operations fail
+    fn list_tags(&self) -> Result<Vec<String>>;
 }

--- a/tests/create_tests.rs
+++ b/tests/create_tests.rs
@@ -189,6 +189,503 @@ fn test_branch_name_sanitization() -> Result<()> {
     Ok(())
 }
 
+/// Test creating worktree with --from flag from different reference types
+#[test]
+fn test_create_worktree_with_from_flag() -> Result<()> {
+    let env = CliTestEnvironment::new()?;
+
+    // Create a test branch and tag for testing --from functionality
+    std::process::Command::new("git")
+        .args(["branch", "test-source-branch"])
+        .current_dir(env.repo_dir.path())
+        .output()?;
+
+    std::process::Command::new("git")
+        .args(["tag", "test-tag-v1.0"])
+        .current_dir(env.repo_dir.path())
+        .output()?;
+
+    // Test 1: Create worktree from specific branch
+    env.run_command(&[
+        "create",
+        "feature/from-branch",
+        "--from",
+        "test-source-branch",
+    ])?
+    .assert()
+    .success()
+    .stdout(predicate::str::contains(
+        "Creating new branch: feature/from-branch",
+    ))
+    .stdout(predicate::str::contains("✓ Worktree created successfully!"));
+
+    env.worktree_path("feature/from-branch")
+        .assert(predicate::path::is_dir());
+
+    // Test 2: Create worktree from tag
+    env.run_command(&["create", "feature/from-tag", "--from", "test-tag-v1.0"])?
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Creating new branch: feature/from-tag",
+        ));
+
+    env.worktree_path("feature/from-tag")
+        .assert(predicate::path::is_dir());
+
+    // Test 3: Create worktree from main branch (existing)
+    env.run_command(&["create", "feature/from-main", "--from", "main"])?
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Creating new branch: feature/from-main",
+        ));
+
+    env.worktree_path("feature/from-main")
+        .assert(predicate::path::is_dir());
+
+    Ok(())
+}
+
+/// Test --from flag with existing branch mode (should ignore --from)
+#[test]
+fn test_create_worktree_from_with_existing_branch_mode() -> Result<()> {
+    let env = CliTestEnvironment::new()?;
+
+    // Create a source branch
+    std::process::Command::new("git")
+        .args(["branch", "source-branch"])
+        .current_dir(env.repo_dir.path())
+        .output()?;
+
+    // Create target branch to use in existing mode
+    std::process::Command::new("git")
+        .args(["branch", "target-branch"])
+        .current_dir(env.repo_dir.path())
+        .output()?;
+
+    // Test: --from should be ignored when using existing branch
+    env.run_command(&[
+        "create",
+        "--existing-branch",
+        "target-branch",
+        "--from",
+        "source-branch",
+    ])?
+    .assert()
+    .success()
+    .stdout(predicate::str::contains(
+        "Using existing branch: target-branch",
+    ));
+
+    env.worktree_path("target-branch")
+        .assert(predicate::path::is_dir());
+
+    Ok(())
+}
+
+/// Test --from flag with --new-branch mode
+#[test]
+fn test_create_worktree_from_with_new_branch_mode() -> Result<()> {
+    let env = CliTestEnvironment::new()?;
+
+    // Create a source branch
+    std::process::Command::new("git")
+        .args(["branch", "source-for-new"])
+        .current_dir(env.repo_dir.path())
+        .output()?;
+
+    // Test: --from should work with --new-branch mode
+    env.run_command(&[
+        "create",
+        "--new-branch",
+        "new-from-source",
+        "--from",
+        "source-for-new",
+    ])?
+    .assert()
+    .success()
+    .stdout(predicate::str::contains(
+        "Creating new branch: new-from-source",
+    ));
+
+    env.worktree_path("new-from-source")
+        .assert(predicate::path::is_dir());
+
+    Ok(())
+}
+
+/// Test error handling for invalid --from references
+#[test]
+fn test_create_worktree_from_invalid_reference() -> Result<()> {
+    let env = CliTestEnvironment::new()?;
+
+    // Test 1: Invalid branch name
+    env.run_command(&["create", "feature/invalid", "--from", "non-existent-branch"])?
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Failed to resolve reference 'non-existent-branch'",
+        ));
+
+    // Test 2: Invalid commit hash
+    env.run_command(&["create", "feature/invalid2", "--from", "abcdef123456"])?
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Failed to resolve reference 'abcdef123456'",
+        ));
+
+    // Test 3: Invalid tag
+    env.run_command(&["create", "feature/invalid3", "--from", "non-existent-tag"])?
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Failed to resolve reference 'non-existent-tag'",
+        ));
+
+    // Verify no worktrees were created
+    assert!(!env.worktree_path("feature/invalid").path().exists());
+    assert!(!env.worktree_path("feature/invalid2").path().exists());
+    assert!(!env.worktree_path("feature/invalid3").path().exists());
+
+    Ok(())
+}
+
+/// Test --list-from-completions flag
+#[test]
+fn test_list_from_completions() -> Result<()> {
+    let env = CliTestEnvironment::new()?;
+
+    // Create some test branches and tags
+    std::process::Command::new("git")
+        .args(["branch", "completion-test-branch"])
+        .current_dir(env.repo_dir.path())
+        .output()?;
+
+    std::process::Command::new("git")
+        .args(["tag", "completion-test-tag"])
+        .current_dir(env.repo_dir.path())
+        .output()?;
+
+    // Test completion output
+    let output = env
+        .run_command(&["create", "dummy", "--list-from-completions"])?
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let stdout_str = String::from_utf8(output)?;
+
+    // Should contain local branches
+    assert!(stdout_str.contains("main"));
+    assert!(stdout_str.contains("completion-test-branch"));
+
+    // Should contain tags
+    assert!(stdout_str.contains("completion-test-tag"));
+
+    // Each reference should be on its own line
+    let lines: Vec<&str> = stdout_str.trim().split('\n').collect();
+    assert!(lines.len() >= 3); // At least main, test-branch, and test-tag
+
+    // Verify format (one reference per line, no extra characters)
+    for line in lines {
+        assert!(!line.trim().is_empty());
+        assert!(!line.contains(' ')); // No spaces in reference names
+    }
+
+    Ok(())
+}
+
+/// Test --from with commit hash
+#[test]
+fn test_create_worktree_from_commit_hash() -> Result<()> {
+    let env = CliTestEnvironment::new()?;
+
+    // Get the current commit hash
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(env.repo_dir.path())
+        .output()?;
+
+    let commit_hash = String::from_utf8(output.stdout)?.trim().to_string();
+
+    // Test creating worktree from full commit hash
+    env.run_command(&["create", "feature/from-commit", "--from", &commit_hash])?
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Creating new branch: feature/from-commit",
+        ));
+
+    env.worktree_path("feature/from-commit")
+        .assert(predicate::path::is_dir());
+
+    // Test creating worktree from short commit hash (first 7 characters)
+    let short_hash = &commit_hash[..7];
+    env.run_command(&["create", "feature/from-short-commit", "--from", short_hash])?
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Creating new branch: feature/from-short-commit",
+        ));
+
+    env.worktree_path("feature/from-short-commit")
+        .assert(predicate::path::is_dir());
+
+    Ok(())
+}
+
+/// Test interactive --from selection functionality with various git references
+#[test]
+fn test_create_worktree_interactive_from_selection() -> Result<()> {
+    // Skip this test in CI environments where TTY is not available
+    if CliTestEnvironment::is_ci() {
+        eprintln!("Skipping interactive test in CI environment");
+        return Ok(());
+    }
+
+    let env = CliTestEnvironment::new()?;
+
+    // Create test references: local branch, remote branch, and tag
+    std::process::Command::new("git")
+        .args(["branch", "test-interactive-branch"])
+        .current_dir(env.repo_dir.path())
+        .output()?;
+
+    std::process::Command::new("git")
+        .args(["tag", "test-interactive-tag"])
+        .current_dir(env.repo_dir.path())
+        .output()?;
+
+    // Create a remote and remote branch
+    std::process::Command::new("git")
+        .args([
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/test/repo.git",
+        ])
+        .current_dir(env.repo_dir.path())
+        .output()?;
+
+    std::process::Command::new("git")
+        .args(["branch", "origin/test-remote-branch"])
+        .current_dir(env.repo_dir.path())
+        .output()?;
+
+    // Test that the interactive mode flag is accepted and launches the interactive UI
+    // The command will fail because there's no TTY for interactive input, but it should
+    // show that the interactive selection was attempted
+    env.run_command(&["create", "test-branch", "--interactive-from"])?
+        .assert()
+        .failure() // Should fail because we don't have interactive input (no TTY)
+        .stderr(predicate::str::contains("Choose a category:"));
+    // This confirms the interactive selection UI was launched
+
+    Ok(())
+}
+
+/// Test interactive selection with no git references available
+#[test]
+fn test_interactive_from_selection_no_references() -> Result<()> {
+    // Create a minimal test environment with no branches or tags
+    let temp_dir = assert_fs::TempDir::new()?;
+    let repo_dir = temp_dir.child("repo");
+    let storage_dir = temp_dir.child("storage");
+
+    // Create actual directories
+    std::fs::create_dir_all(&repo_dir)?;
+    std::fs::create_dir_all(&storage_dir)?;
+
+    // Initialize empty git repo (no commits, no branches beyond initial)
+    std::process::Command::new("git")
+        .args(["init"])
+        .current_dir(&repo_dir)
+        .output()?;
+
+    // First build the binary
+    let project_root = std::env::current_dir()?; // Get the project root
+    std::process::Command::new("cargo")
+        .args(["build", "--bin", "worktree-bin"])
+        .current_dir(&project_root)
+        .output()?;
+
+    // Test the interactive mode with no references
+    let binary_path = project_root.join("target/debug/worktree-bin");
+    let cmd_result = std::process::Command::new(&binary_path)
+        .args(["create", "test", "--interactive-from"])
+        .current_dir(&repo_dir) // Run from the git repo directory
+        .env("HOME", storage_dir.path())
+        .env("WORKTREE_STORAGE_ROOT", storage_dir.path()) // Set storage root
+        .output()?;
+
+    // Should fail with "No git references found" error
+    assert!(!cmd_result.status.success());
+    let stderr = String::from_utf8(cmd_result.stderr)?;
+    assert!(stderr.contains("No git references found"));
+
+    Ok(())
+}
+
+/// Test that create command with no arguments triggers interactive workflow
+#[test]
+fn test_create_interactive_workflow_trigger() -> Result<()> {
+    // Skip this test in CI environments where TTY is not available
+    if CliTestEnvironment::is_ci() {
+        eprintln!("Skipping interactive test in CI environment");
+        return Ok(());
+    }
+
+    let env = CliTestEnvironment::new()?;
+
+    // Test that the interactive workflow is launched when no branch name is provided
+    // The command will fail because there's no TTY for interactive input, but it should
+    // show the interactive branch name prompt
+    env.run_command(&["create"])?
+        .assert()
+        .failure() // Should fail because we don't have interactive input (no TTY)
+        .stderr(predicate::str::contains(
+            "Enter the branch name for the new worktree",
+        ));
+    // This confirms the interactive workflow was launched
+
+    Ok(())
+}
+
+/// Test that list-from-completions works correctly for shell completion
+#[test]
+fn test_list_from_completions_integration() -> Result<()> {
+    let env = CliTestEnvironment::new()?;
+
+    // Create some test references
+    std::process::Command::new("git")
+        .args(["branch", "feature/test-branch"])
+        .current_dir(env.repo_dir.path())
+        .output()?;
+
+    std::process::Command::new("git")
+        .args(["tag", "v1.0.0"])
+        .current_dir(env.repo_dir.path())
+        .output()?;
+
+    // Test the list-from-completions output
+    let mut cmd = env.run_command(&["create", "dummy", "--list-from-completions"])?;
+    cmd.assert().success();
+    let output = cmd.output()?;
+
+    let stdout = String::from_utf8(output.stdout)?;
+    let lines: Vec<&str> = stdout.lines().collect();
+
+    // Should contain our test references
+    assert!(lines.contains(&"main"));
+    assert!(lines.contains(&"feature/test-branch"));
+    assert!(lines.contains(&"v1.0.0"));
+
+    Ok(())
+}
+
+/// Test that the create command help shows expected flags
+#[test]
+fn test_create_command_help() -> Result<()> {
+    let env = CliTestEnvironment::new()?;
+
+    // Test that help output shows the expected user-facing flags
+    env.run_command(&["create", "--help"])?
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--from"))
+        .stdout(predicate::str::contains("--new-branch"))
+        .stdout(predicate::str::contains("--existing-branch"));
+
+    Ok(())
+}
+
+/// Test branch name validation function
+#[test]
+fn test_branch_name_validation() {
+    use inquire::validator::Validation;
+    use worktree::commands::create::validate_branch_name_internal;
+
+    // Valid names - should return Validation::Valid
+    assert!(matches!(
+        validate_branch_name_internal("feature/auth"),
+        Validation::Valid
+    ));
+    assert!(matches!(
+        validate_branch_name_internal("bugfix-123"),
+        Validation::Valid
+    ));
+    assert!(matches!(
+        validate_branch_name_internal("main"),
+        Validation::Valid
+    ));
+    assert!(matches!(
+        validate_branch_name_internal("develop"),
+        Validation::Valid
+    ));
+    assert!(matches!(
+        validate_branch_name_internal("feature_branch"),
+        Validation::Valid
+    ));
+
+    // Invalid names - should return Validation::Invalid(...)
+    assert!(matches!(
+        validate_branch_name_internal(""),
+        Validation::Invalid(_)
+    ));
+    assert!(matches!(
+        validate_branch_name_internal("   "),
+        Validation::Invalid(_)
+    ));
+    assert!(matches!(
+        validate_branch_name_internal("feature..auth"),
+        Validation::Invalid(_)
+    ));
+    assert!(matches!(
+        validate_branch_name_internal("/feature"),
+        Validation::Invalid(_)
+    ));
+    assert!(matches!(
+        validate_branch_name_internal("feature/"),
+        Validation::Invalid(_)
+    ));
+    assert!(matches!(
+        validate_branch_name_internal("feature auth"),
+        Validation::Invalid(_)
+    ));
+    assert!(matches!(
+        validate_branch_name_internal("feature~"),
+        Validation::Invalid(_)
+    ));
+    assert!(matches!(
+        validate_branch_name_internal("feature^"),
+        Validation::Invalid(_)
+    ));
+    assert!(matches!(
+        validate_branch_name_internal("feature:"),
+        Validation::Invalid(_)
+    ));
+    assert!(matches!(
+        validate_branch_name_internal("feature?"),
+        Validation::Invalid(_)
+    ));
+    assert!(matches!(
+        validate_branch_name_internal("feature*"),
+        Validation::Invalid(_)
+    ));
+    assert!(matches!(
+        validate_branch_name_internal("feature["),
+        Validation::Invalid(_)
+    ));
+    assert!(matches!(
+        validate_branch_name_internal("feature\\"),
+        Validation::Invalid(_)
+    ));
+}
+
 #[cfg(test)]
 mod integration_tests {
     use super::*;

--- a/tests/test-support/src/test_env.rs
+++ b/tests/test-support/src/test_env.rs
@@ -40,6 +40,9 @@ impl CliTestEnvironment {
         repo_dir.child("README.md").write_str("# Test Repo")?;
         Self::run_git_command(&repo_dir, &["add", "."])?;
         Self::run_git_command(&repo_dir, &["commit", "-m", "Initial commit"])?;
+        
+        // Ensure we have a main branch (some git versions default to 'master')
+        Self::run_git_command(&repo_dir, &["branch", "-M", "main"])?;
 
         Ok(Self {
             repo_dir,
@@ -84,6 +87,16 @@ impl CliTestEnvironment {
         // Use the same sanitization logic as the main application
         let sanitized = branch_name.replace('/', "-");
         self.storage_dir.child("test_repo").child(&sanitized)
+    }
+    
+    /// Check if we're running in a CI environment (where TTY is not available)
+    pub fn is_ci() -> bool {
+        // Check for common CI environment variables
+        std::env::var("CI").is_ok() || 
+        std::env::var("GITHUB_ACTIONS").is_ok() ||
+        std::env::var("GITLAB_CI").is_ok() ||
+        std::env::var("TRAVIS").is_ok() ||
+        std::env::var("CIRCLECI").is_ok()
     }
 }
 


### PR DESCRIPTION
# Enhanced Git Reference Selection for `worktree create`

### TL;DR

Add hierarchical interactive selection for git references when creating worktrees, improving the user experience with a cleaner, more organized interface.

### What changed?

- Added a new `--from` flag to the `create` command that accepts a starting point (branch, commit, tag)
- Implemented two-step hierarchical selection UI for git references:
  1. First select category (Local Branches, Remote Branches, Tags)
  2. Then select specific reference from that category
- Enhanced shell completion for bash, zsh, and fish to support the new interactive mode
- Added `--interactive-from` flag for guided reference selection
- Implemented fully interactive workflow when running `worktree create` with no arguments
- Added comprehensive test coverage for all new functionality
- Updated the git operations interface to support creating worktrees from specific references
- Added GitHub Actions CI workflow for automated testing

### How to test?

1. Create a worktree from a specific reference:
   ```bash
   worktree create feature/mybranch --from main
   ```

2. Try the interactive selection:
   ```bash
   worktree create feature/mybranch --interactive-from
   ```
   This displays a hierarchical picker with categories of git references.

3. Use the fully interactive workflow:
   ```bash
   worktree create
   ```
   This prompts for branch name and then reference selection.

4. Test with different reference types:
   ```bash
   worktree create feature/from-tag --from v1.0.0
   worktree create feature/from-commit --from <commit-hash>
   ```

### Why make this change?

The previous implementation made it difficult to select references when there were many options, as all references (branches, tags, etc.) were presented in a single flat list with non-selectable separator items. This change improves usability by:

1. Organizing references into logical categories
2. Eliminating confusion from trying to select non-selectable separator items
3. Providing clear counts of items in each category
4. Maintaining all existing functionality while providing a cleaner navigation experience