### PR TITLE
Add `ls` alias for `list` subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`ls` alias for `list`:** `worktree ls` is equivalent to `worktree list` (including `--current`). The alias appears in help and generated shell completions; bash/zsh integration fallbacks include it when clap completions are unavailable.
+
 ## [0.5.0] - 2026-03-24
 
 ### Added

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -180,7 +180,7 @@ _worktree_complete() {{
             COMP_WORDS=("${{saved_comp_words[@]}}")
         else
             # Fallback to basic completion
-            COMPREPLY=($(compgen -W "create list remove status sync-config jump switch back init completions cleanup --help --version" -- "$cur"))
+            COMPREPLY=($(compgen -W "create list ls remove status sync-config jump switch back init completions cleanup --help --version" -- "$cur"))
         fi
     fi
 }}
@@ -393,6 +393,7 @@ _worktree() {{
                     subcommands=(
                         'create:Create a new worktree'
                         'list:List all worktrees'
+                        'ls:List worktrees (alias for list)'
                         'remove:Remove a worktree'
                         'status:Show worktree status'
                         'sync-config:Sync config files between worktrees'

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,7 @@ enum Commands {
         list_from_completions: bool,
     },
     /// List all worktrees
+    #[command(visible_alias = "ls")]
     List {
         /// Show worktrees for current repo only
         #[arg(long)]

--- a/tests/list_tests.rs
+++ b/tests/list_tests.rs
@@ -62,6 +62,26 @@ fn test_list_multiple_worktrees() -> Result<()> {
     Ok(())
 }
 
+/// `ls` is a visible alias for `list`
+#[test]
+fn test_list_ls_alias() -> Result<()> {
+    let env = CliTestEnvironment::new()?;
+
+    env.run_command(&["create", "alias-test", "feature/alias-test"])?
+        .assert()
+        .success();
+
+    let from_list = get_stdout(&env, &["list"])?;
+    let from_ls = get_stdout(&env, &["ls"])?;
+    assert_eq!(from_list, from_ls);
+
+    let from_list_current = get_stdout(&env, &["list", "--current"])?;
+    let from_ls_current = get_stdout(&env, &["ls", "--current"])?;
+    assert_eq!(from_list_current, from_ls_current);
+
+    Ok(())
+}
+
 /// Test list command with current repo flag
 #[test]
 fn test_list_current_repo() -> Result<()> {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a visible `ls` subcommand alias for `list`, matching the existing `jump` / `switch` pattern.

## Changes

- **CLI**: `#[command(visible_alias = "ls")]` on the `List` variant in `src/main.rs` so `worktree ls` and `worktree list` share the same behavior and flags (`--current`).
- **Shell integration**: Bash `compgen` fallback and Zsh `_describe` fallback now include `ls` when clap completions are unavailable.
- **Tests**: `test_list_ls_alias` in `tests/list_tests.rs` asserts identical stdout for `list` vs `ls` (with and without `--current`).
- **Changelog**: Entry under `[Unreleased]` → `### Added` in `CHANGELOG.md`.

Generated completions (`worktree completions …`) pick up the alias automatically from clap.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-30e23729-47ad-40ee-8b05-95d75009b1bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-30e23729-47ad-40ee-8b05-95d75009b1bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ls` as an alias for the `list` subcommand, enabling `worktree ls` as an equivalent to `worktree list`. The alias supports all flags and is included in shell completions for bash and zsh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->